### PR TITLE
Tower Targeting reworked

### DIFF
--- a/TowerDefense/Assets/AddressableAssetsData/AddressableAssetSettings.asset
+++ b/TowerDefense/Assets/AddressableAssetsData/AddressableAssetSettings.asset
@@ -15,7 +15,7 @@ MonoBehaviour:
   m_DefaultGroup: 6c79af887fca34d42aa5b7846ca9ef27
   m_currentHash:
     serializedVersion: 2
-    Hash: 9ce9c642b9970f73660ad43b07ada919
+    Hash: 00000000000000000000000000000000
   m_OptimizeCatalogSize: 0
   m_BuildRemoteCatalog: 0
   m_CatalogRequestsTimeout: 0

--- a/TowerDefense/Assets/AddressableAssetsData/AssetGroups/Towers.asset
+++ b/TowerDefense/Assets/AddressableAssetsData/AssetGroups/Towers.asset
@@ -20,6 +20,11 @@ MonoBehaviour:
     m_ReadOnly: 0
     m_SerializedLabels: []
     FlaggedDuringContentUpdateRestriction: 0
+  - m_GUID: bfdbad2dc02ee5647ab14fcd3ad549a6
+    m_Address: CreepSmiter9000
+    m_ReadOnly: 0
+    m_SerializedLabels: []
+    FlaggedDuringContentUpdateRestriction: 0
   - m_GUID: c1b5cfa6004f9ff49a9edfa2b82e20a8
     m_Address: Pill_Fish
     m_ReadOnly: 0

--- a/TowerDefense/Assets/DataAssets/Animations/CreepSmiter9000 Animations.asset
+++ b/TowerDefense/Assets/DataAssets/Animations/CreepSmiter9000 Animations.asset
@@ -1,0 +1,31 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db1daed8d762ad34384136f7c181992d, type: 3}
+  m_Name: CreepSmiter9000 Animations
+  m_EditorClassIdentifier: Assembly-CSharp::SpriteAnimationData
+  idleAnimation: 0
+  animations:
+  - animationSprites:
+    - {fileID: -1653287097, guid: 85edf037a3d70f149b152e5e80add369, type: 3}
+    - {fileID: -185015308, guid: 85edf037a3d70f149b152e5e80add369, type: 3}
+    - {fileID: -1653287097, guid: 85edf037a3d70f149b152e5e80add369, type: 3}
+    - {fileID: -185015308, guid: 85edf037a3d70f149b152e5e80add369, type: 3}
+    framesPerSecond: 2
+    looping: 1
+  - animationSprites:
+    - {fileID: -526492231, guid: 85edf037a3d70f149b152e5e80add369, type: 3}
+    - {fileID: -526492231, guid: 85edf037a3d70f149b152e5e80add369, type: 3}
+    - {fileID: 1175978912, guid: 85edf037a3d70f149b152e5e80add369, type: 3}
+    - {fileID: -526492231, guid: 85edf037a3d70f149b152e5e80add369, type: 3}
+    - {fileID: -1653287097, guid: 85edf037a3d70f149b152e5e80add369, type: 3}
+    framesPerSecond: 5
+    looping: 0

--- a/TowerDefense/Assets/DataAssets/Animations/CreepSmiter9000 Animations.asset.meta
+++ b/TowerDefense/Assets/DataAssets/Animations/CreepSmiter9000 Animations.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ab1f43a9f895ac2438f9442c6622af52
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefense/Assets/DataAssets/Towers/CreepSmiter9000.asset
+++ b/TowerDefense/Assets/DataAssets/Towers/CreepSmiter9000.asset
@@ -10,16 +10,17 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: 6745eb02c5789024a8f06b089ab7bb52, type: 3}
-  m_Name: Pill_Fish
+  m_Name: CreepSmiter9000
   m_EditorClassIdentifier: Assembly-CSharp::TowerData
-  projectileSprite: {fileID: 21300000, guid: 6b14fa792f77fc34e9ca4feaefea88e6, type: 3}
-  animationData: {fileID: 11400000, guid: b785dc0fc5b6e534e84e6436a9fbbc4b, type: 2}
-  targetRadius: 3
-  damagePerShot: 1
-  shotsPerSecond: 1
-  projectileTargetTime: 0.5
+  projectileSprite: {fileID: 0}
+  animationData: {fileID: 11400000, guid: ab1f43a9f895ac2438f9442c6622af52, type: 2}
+  targetRadius: 999
+  damagePerShot: 100000000
+  shotsPerSecond: 0.1
+  projectileTargetTime: 0
   firingDelay: 0.4
-  creepsToTarget: 1
-  slowable: 1
-  cost: 10
-  notes: Basic tower that does basic things - Change in future
+  creepsToTarget: 3
+  slowable: 0
+  cost: 999
+  notes: FOR THE LOVE OF GOD, DONT PUT THIS IN AN ACTUAL LEVEL. Just used to test
+    tower targetting stuff

--- a/TowerDefense/Assets/DataAssets/Towers/CreepSmiter9000.asset.meta
+++ b/TowerDefense/Assets/DataAssets/Towers/CreepSmiter9000.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bfdbad2dc02ee5647ab14fcd3ad549a6
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/TowerDefense/Assets/DataAssets/Towers/IV_Stingray.asset
+++ b/TowerDefense/Assets/DataAssets/Towers/IV_Stingray.asset
@@ -19,5 +19,7 @@ MonoBehaviour:
   shotsPerSecond: 3
   projectileTargetTime: 0
   firingDelay: 0
+  creepsToTarget: 1
   slowable: 1
   cost: 14
+  notes: Close Range Tower with high attack rate, immune to slowing effects

--- a/TowerDefense/Assets/Scenes/Level1.unity
+++ b/TowerDefense/Assets/Scenes/Level1.unity
@@ -285,7 +285,7 @@ MonoBehaviour:
       deleyPerCreep: 0.5
     delayBeforeWave: 5
   paths:
-  - 0,1,2,3,4,5,6
+  - 0
   creepParent: {fileID: 1313844446}
   towerParent: {fileID: 778779257}
   towerKeys:
@@ -374,142 +374,6 @@ Transform:
   - {fileID: 1197629561}
   m_Father: {fileID: 352520483}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &97394231
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 97394232}
-  - component: {fileID: 97394234}
-  - component: {fileID: 97394233}
-  m_Layer: 5
-  m_Name: Notifications
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &97394232
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 97394231}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 5, y: 5, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 395627485}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &97394233
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 97394231}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 32
-  m_fontSizeBase: 32
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 2
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &97394234
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 97394231}
-  m_CullTransparentMesh: 1
 --- !u!1 &113229321
 GameObject:
   m_ObjectHideFlags: 0
@@ -1420,112 +1284,11 @@ Transform:
   - {fileID: 1035665639}
   m_Father: {fileID: 322540210}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1 &395627481
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 395627485}
-  - component: {fileID: 395627484}
-  - component: {fileID: 395627483}
-  - component: {fileID: 395627482}
-  m_Layer: 5
-  m_Name: Canvas
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &395627482
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 395627481}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.GraphicRaycaster
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &395627483
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 395627481}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: UnityEngine.UI::UnityEngine.UI.CanvasScaler
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!223 &395627484
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 395627481}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_VertexColorAlwaysGammaSpace: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
-  m_TargetDisplay: 0
---- !u!224 &395627485
+--- !u!224 &395627485 stripped
 RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
+  m_CorrespondingSourceObject: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+  m_PrefabInstance: {fileID: 903003911}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 395627481}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1097169949}
-  - {fileID: 97394232}
-  - {fileID: 1889446870}
-  - {fileID: 545991438}
-  - {fileID: 1931033027}
-  m_Father: {fileID: 2027374973}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
 --- !u!1 &410411491
 GameObject:
   m_ObjectHideFlags: 0
@@ -1711,144 +1474,6 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 8841404153563855577, guid: 549daac245f86e14abb792cf0daa4ebc, type: 3}
   m_PrefabInstance: {fileID: 530393013}
   m_PrefabAsset: {fileID: 0}
---- !u!1 &545991437
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 545991438}
-  - component: {fileID: 545991440}
-  - component: {fileID: 545991439}
-  m_Layer: 5
-  m_Name: Waves
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &545991438
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 545991437}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 395627485}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 800, y: 450}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &545991439
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 545991437}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: 'Waves
-
-'
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 32
-  m_fontSizeBase: 32
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &545991440
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 545991437}
-  m_CullTransparentMesh: 1
 --- !u!1 &593495936
 GameObject:
   m_ObjectHideFlags: 0
@@ -3000,6 +2625,151 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1001 &903003911
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 2027374973}
+    m_Modifications:
+    - target: {fileID: 207488607324086179, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207488607324086179, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207488607324086179, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207488607324086179, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 388735597552235667, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 388735597552235667, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 388735597552235667, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 388735597552235667, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_Pivot.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_Pivot.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMin.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8309712301052199188, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_Name
+      value: HUD
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887954077348950101, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887954077348950101, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887954077348950101, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887954077348950101, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
 --- !u!1 &909336819
 GameObject:
   m_ObjectHideFlags: 0
@@ -3609,142 +3379,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1097169948
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1097169949}
-  - component: {fileID: 1097169951}
-  - component: {fileID: 1097169950}
-  m_Layer: 5
-  m_Name: Health
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1097169949
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1097169948}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 395627485}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -800, y: 450}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1097169950
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1097169948}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Health
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 32
-  m_fontSizeBase: 32
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &1097169951
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1097169948}
-  m_CullTransparentMesh: 1
 --- !u!1 &1177223811
 GameObject:
   m_ObjectHideFlags: 0
@@ -3995,13 +3629,14 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1313844446
-RectTransform:
+--- !u!4 &1313844446
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1313844445}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -4009,11 +3644,6 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 135671655}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 5}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1315482748
 GameObject:
   m_ObjectHideFlags: 0
@@ -5411,142 +5041,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1889446869
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1889446870}
-  - component: {fileID: 1889446872}
-  - component: {fileID: 1889446871}
-  m_Layer: 5
-  m_Name: Currency
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1889446870
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1889446869}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 395627485}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -800, y: 400}
-  m_SizeDelta: {x: 200, y: 50}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1889446871
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1889446869}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Unity.TextMeshPro::TMPro.TextMeshProUGUI
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_text: Currency
-  m_isRightToLeft: 0
-  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
-  m_fontSharedMaterials: []
-  m_fontMaterial: {fileID: 0}
-  m_fontMaterials: []
-  m_fontColor32:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
-  m_enableVertexGradient: 0
-  m_colorMode: 3
-  m_fontColorGradient:
-    topLeft: {r: 1, g: 1, b: 1, a: 1}
-    topRight: {r: 1, g: 1, b: 1, a: 1}
-    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
-    bottomRight: {r: 1, g: 1, b: 1, a: 1}
-  m_fontColorGradientPreset: {fileID: 0}
-  m_spriteAsset: {fileID: 0}
-  m_tintAllSprites: 0
-  m_StyleSheet: {fileID: 0}
-  m_TextStyleHashCode: -1183493901
-  m_overrideHtmlColors: 0
-  m_faceColor:
-    serializedVersion: 2
-    rgba: 4294967295
-  m_fontSize: 32
-  m_fontSizeBase: 32
-  m_fontWeight: 400
-  m_enableAutoSizing: 0
-  m_fontSizeMin: 18
-  m_fontSizeMax: 72
-  m_fontStyle: 0
-  m_HorizontalAlignment: 1
-  m_VerticalAlignment: 256
-  m_textAlignment: 65535
-  m_characterSpacing: 0
-  m_wordSpacing: 0
-  m_lineSpacing: 0
-  m_lineSpacingMax: 0
-  m_paragraphSpacing: 0
-  m_charWidthMaxAdj: 0
-  m_TextWrappingMode: 1
-  m_wordWrappingRatios: 0.4
-  m_overflowMode: 0
-  m_linkedTextComponent: {fileID: 0}
-  parentLinkedComponent: {fileID: 0}
-  m_enableKerning: 0
-  m_ActiveFontFeatures: 6e72656b
-  m_enableExtraPadding: 0
-  checkPaddingRequired: 0
-  m_isRichText: 1
-  m_EmojiFallbackSupport: 1
-  m_parseCtrlCharacters: 1
-  m_isOrthographic: 1
-  m_isCullingEnabled: 0
-  m_horizontalMapping: 0
-  m_verticalMapping: 0
-  m_uvLineOffset: 0
-  m_geometrySortingOrder: 0
-  m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 0
-  m_useMaxVisibleDescender: 1
-  m_pageToDisplay: 1
-  m_margin: {x: 0, y: 0, z: 0, w: 0}
-  m_isUsingLegacyAnimationComponent: 0
-  m_isVolumetricText: 0
-  m_hasFontAssetChanged: 0
-  m_baseMaterial: {fileID: 0}
-  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &1889446872
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1889446869}
-  m_CullTransparentMesh: 1
 --- !u!1 &1910805041
 GameObject:
   m_ObjectHideFlags: 0
@@ -5750,7 +5244,7 @@ MonoBehaviour:
     - Position:
         x: 7
         y: 5
-        z: 3
+        z: 0
       TangentIn:
         x: 0
         y: 0
@@ -5933,59 +5427,6 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!1 &1931033026
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1931033027}
-  - component: {fileID: 1931033028}
-  m_Layer: 5
-  m_Name: UIMaster
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1931033027
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1931033026}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 395627485}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1931033028
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1931033026}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 4f9eb9d56998ee441b1b89a0d7f8617b, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: Assembly-CSharp::UIController
-  currentHealth: {fileID: 1097169950}
-  currentCurrency: {fileID: 1889446871}
-  currentWave: {fileID: 545991439}
-  playRateButtons: []
-  endGameText: {fileID: 97394233}
 --- !u!1 &1936673287
 GameObject:
   m_ObjectHideFlags: 0

--- a/TowerDefense/Assets/Scenes/Main Menu.unity
+++ b/TowerDefense/Assets/Scenes/Main Menu.unity
@@ -854,13 +854,14 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &1313844446
-RectTransform:
+--- !u!4 &1313844446
+Transform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1313844445}
+  serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
@@ -868,11 +869,6 @@ RectTransform:
   m_Children: []
   m_Father: {fileID: 135671655}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 20, y: 5}
-  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1452370630
 GameObject:
   m_ObjectHideFlags: 0
@@ -968,7 +964,7 @@ GameObject:
   - component: {fileID: 1637384902}
   - component: {fileID: 1637384901}
   m_Layer: 0
-  m_Name: GameObject
+  m_Name: Managers
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1665,7 +1661,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::MenuController
   dedicatedTowerSpot: {fileID: 8841404152954107813}
-  creepOrganizer: {fileID: 0}
+  creepOrganizer: {fileID: 1313844446}
   basicTower: {fileID: 11400000, guid: c1b5cfa6004f9ff49a9edfa2b82e20a8, type: 2}
   basicCreep: {fileID: 11400000, guid: 39ce106295c99f445b6a48a065ae65d7, type: 2}
 --- !u!212 &1488166898323834025

--- a/TowerDefense/Assets/Scenes/Prototype.unity
+++ b/TowerDefense/Assets/Scenes/Prototype.unity
@@ -149,7 +149,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9efb4a3ee84c1bd4c85f31d758697dc9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::MasterController
-  startingCurrency: 10
+  startingCurrency: 99999999
   startingHealth: 5
   waves:
   - name: Wave 1
@@ -194,6 +194,7 @@ MonoBehaviour:
   towerKeys:
   - Pill_Fish
   - IV_Stingray
+  - CreepSmiter9000
   creepKeys:
   - BasicCreep
   - BossCreep
@@ -1577,6 +1578,38 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 2027374973}
     m_Modifications:
+    - target: {fileID: 207488607324086179, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207488607324086179, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207488607324086179, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 207488607324086179, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 388735597552235667, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 388735597552235667, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 388735597552235667, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 388735597552235667, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
       propertyPath: m_Pivot.x
       value: 0
@@ -1672,6 +1705,22 @@ PrefabInstance:
     - target: {fileID: 8309712301052199188, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
       propertyPath: m_Name
       value: HUD
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887954077348950101, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887954077348950101, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887954077348950101, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8887954077348950101, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []

--- a/TowerDefense/Assets/Scripts/MenuController.cs
+++ b/TowerDefense/Assets/Scripts/MenuController.cs
@@ -19,7 +19,7 @@ public class MenuController : MonoBehaviour
 
     IEnumerator CreepLoop()
     {
-        WaitForSeconds delay = new(1.2f);
+        WaitForSeconds delay = new(2.01f);
         while (true)
         {
             GameObject newCreep = Creep.CreateNewCreep(basicCreep, new List<int>() { 0 });

--- a/TowerDefense/Assets/Scripts/TowerScripts/Tower.cs
+++ b/TowerDefense/Assets/Scripts/TowerScripts/Tower.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Device;
+using static UnityEditor.ShaderGraph.Internal.KeywordDependentCollection;
 
 public class Tower : MonoBehaviour
 {
@@ -14,7 +15,7 @@ public class Tower : MonoBehaviour
     // ---------- Tower Slow ----------
 
     private float baseShotsPerSecond;
-    private int slowCount = 0; 
+    private int slowCount = 0;
     private float strongestSlow = 1f;
     #region Slow Functions
     public void ApplySlow(float multiplier)
@@ -45,6 +46,7 @@ public class Tower : MonoBehaviour
     private float shotsPerSecond;
     private float projectileTargetTime;
     private float firingDelay;
+    private int creepsToTarget;
     public bool slowable { get; private set; }
 
     private int cost;
@@ -61,8 +63,8 @@ public class Tower : MonoBehaviour
     public static GameObject CreateNewTower(TowerData creationData)
     {
         //Create our new tower and its associated range object
-        GameObject newTowerObject = new GameObject(creationData.name, new System.Type[] {typeof(Tower), typeof(SpriteRenderer), typeof(CircleCollider2D), typeof(SpriteAnimationSystem) });
-        GameObject newTowerRangeObject = new GameObject("TowerRange", new System.Type[] {typeof(CircleCollider2D)} );
+        GameObject newTowerObject = new GameObject(creationData.name, typeof(Tower), typeof(SpriteRenderer), typeof(CircleCollider2D), typeof(SpriteAnimationSystem));
+        GameObject newTowerRangeObject = new GameObject("TowerRange",  typeof(CircleCollider2D));
 
         SpriteRenderer renderer = newTowerObject.GetComponent<SpriteRenderer>();
         CircleCollider2D collider = newTowerObject.GetComponent<CircleCollider2D>();
@@ -95,6 +97,7 @@ public class Tower : MonoBehaviour
         shotsPerSecond = creationData.shotsPerSecond;
         projectileTargetTime = creationData.projectileTargetTime;
         firingDelay = creationData.firingDelay;
+        creepsToTarget = creationData.creepsToTarget;
         slowable = creationData.slowable;
         cost = creationData.cost;
         this.rangeCollider = rangeCollider;
@@ -128,54 +131,132 @@ public class Tower : MonoBehaviour
         contactFilter.layerMask = LayerMask.GetMask("Creeps");
         List<Collider2D> overlaps = new();
 
-        while(towerEnabled)
+        while (towerEnabled)
         {
             overlaps.Clear();
             rangeCollider.Overlap(contactFilter, overlaps);
-            Collider2D furthestCreep = null;
-            float furthestProgress = -1;
 
-            foreach(Collider2D creep in overlaps)
+            //if nothing overlapping, dont continue, wait a frame then start again
+            if( overlaps.Count  == 0)
             {
-                Creep creepComponent = creep.GetComponent<Creep>();
-                float distance = Vector2.Distance(transform.position, creep.transform.position);
-                if (creepComponent == null || creepComponent.targetHealth <= 0 || distance > rangeCollider.radius)
-                {
-                    continue;
-                }
-                float progress = creep.GetComponent<Creep>().GetProgress();
-                if(progress > furthestProgress)
-                {
-                    furthestProgress = progress;
-                    furthestCreep = creep;
-                }
+                yield return null;
+                continue;
             }
 
+            List<Creep> targetableCreeps = ValidateTargetableCreeps(overlaps);
 
-            //minor changes below, if the tower shoots, we want to wait the delay before it can shoot again, but once it can check again, check as fast as possible to reduce weird delays
-            if(furthestCreep != null)
+            //If nothing is actually targetable, don't ocntinue, wait a frame, then start again
+            if(targetableCreeps.Count == 0)
             {
-                Creep targetCreep = furthestCreep.GetComponent<Creep>();
+                yield return null;
+                continue;
+            }
+
+            /*
+             In both instances below, we AssignDamage before we actually wait and fire so other towers know that this creep is bout to die anyways and not bother targeting and creating issues
+             */
+
+
+            if (targetableCreeps.Count <= creepsToTarget)
+            {
+                //If the number of creeps we can target is <= to the max the tower can target, don't bother checking the furthest along and just smite them all
                 animationSystem.PlayAnimation(1);
-                targetCreep.DecreaseTargetHealth(damagePerShot);
+                AssignDamage(targetableCreeps);
                 yield return firingDelayWait;
-                ProjectileManager.Instance.FireProjectile(transform.position, targetCreep.transform, projectileTargetTime, projectileSprite, () => DamageCreep(targetCreep));
-                audioManager.PlaySFX(audioManager.basicAttackSFX); // Will need to change dynamically in the future, likely just based on index
+                DealDamage(targetableCreeps);
+                audioManager.PlaySFX(audioManager.basicAttackSFX);
                 yield return new WaitForSeconds((1 / shotsPerSecond) - firingDelay);
             }
             else
             {
-                yield return null;
+                List<Creep> furthestCreeps = new();
+                
+                /*
+                 If we have more creeps in range than the tower can target at once, then we want to search through all the targetable ones and pick out the furthest
+                Once we do that, we can target the rest.
+                 */
+
+                for (int i = 0; i < creepsToTarget; i++)
+                {
+                    float furthestProgress = -1;
+                    int furthestIndex = 0;
+                    for(int j = 0;  j < targetableCreeps.Count; j++)
+                    {
+                        float progress = targetableCreeps[j].GetComponent<Creep>().GetProgress();
+                        if(progress > furthestProgress)
+                        {
+                            furthestIndex = j;
+                            furthestProgress = progress;
+                        }
+                    }
+                    furthestCreeps.Add(targetableCreeps[furthestIndex]);
+                    targetableCreeps.RemoveAt(furthestIndex);
+                }
+                if(furthestCreeps.Count > 0)
+                {
+                    animationSystem.PlayAnimation(1);
+                    AssignDamage(furthestCreeps);
+                    yield return firingDelayWait;
+                    DealDamage(furthestCreeps);
+                    audioManager.PlaySFX(audioManager.basicAttackSFX);
+                    yield return new WaitForSeconds((1 / shotsPerSecond) - firingDelay);
+                }
+                else
+                {
+                    yield return null;
+                }
             }
         }
     }
 
-      private void DamageCreep(Creep targetCreep)
-      {
-         if (targetCreep != null)
-         { 
-             targetCreep.DamageCreep(damagePerShot); 
-         }
-      }
+    private List<Creep> ValidateTargetableCreeps(List<Collider2D> overlaps)
+    {
+        List<Creep> targetable = new();
+        foreach (Collider2D creep in overlaps)
+        {
+            Creep creepComponent = creep.GetComponent<Creep>();
+            float distance = Vector2.Distance(transform.position, creep.transform.position);
+            if (creepComponent != null && creepComponent.targetHealth > 0 && distance <= rangeCollider.radius)
+            {
+                targetable.Add(creepComponent);
+            }
+        }
+        return targetable;
+    }
+
+    /// <summary>
+    /// specifically runs through the creeps to damage and sets their furture health to what it would be
+    /// after the shot so other towers know whether its worht to fire or not
+    /// </summary>
+    /// <param name="toDamage">target creeps list</param>
+    private void AssignDamage(List<Creep> toDamage)
+    {
+        foreach (Creep creep in toDamage)
+        {
+            creep.DecreaseTargetHealth(damagePerShot);
+        }
+    }
+
+    /// <summary>
+    /// Specifically runs through the creeps to damage and actually runs the logic to create the "projectiles" that will damage/smite the creeps
+    /// once they reach the target
+    /// </summary>
+    /// <param name="toDamage">target creeps list</param>
+    private void DealDamage(List<Creep> toDamage)
+    {
+        foreach(Creep creep in toDamage)
+        {
+            Creep c = creep;
+            ProjectileManager.Instance.FireProjectile(transform.position, c.transform, projectileTargetTime, projectileSprite, () => DamageCreep(c));
+        }
+    }
+
+    private void DamageCreep(Creep targetCreep)
+    {
+        if (targetCreep != null)
+        {
+            targetCreep.DamageCreep(damagePerShot);
+        }
+    }
 
 }

--- a/TowerDefense/Assets/Scripts/TowerScripts/TowerData.cs
+++ b/TowerDefense/Assets/Scripts/TowerScripts/TowerData.cs
@@ -17,7 +17,12 @@ public class TowerData : ScriptableObject
     public float projectileTargetTime;
     [Tooltip("just used to sync up the animation to firing"), Min(0)]
     public float firingDelay;
+    [Min(1), Tooltip("Put an obscenly high value if you want the tower to target everything in range")]
+    public int creepsToTarget = 1;
     public bool slowable = true;
 
     public int cost;
+
+    [Tooltip("Not referenced anywhere in code atm, just use to make not or other things")]
+    public string notes;
 }

--- a/TowerDefense/Assets/Scripts/TowerScripts/TowerIndex.cs
+++ b/TowerDefense/Assets/Scripts/TowerScripts/TowerIndex.cs
@@ -1,3 +1,4 @@
+using TMPro;
 using UnityEngine;
 
 //Petition to rename this class to something more descriptive? - JGN
@@ -8,11 +9,16 @@ public class IndexSquare : MonoBehaviour
     private SpriteRenderer sr;
 
     private float targetScale = 1;
+    private Vector3 targetLocalPosition = Vector3.zero;
 
-    public void Setup(int spotIndex)
+    float targetAlpha;
+
+    public void Setup(int spotIndex, Vector3 targetPos, bool visisble)
     {
         index = spotIndex;
         sr = GetComponent<SpriteRenderer>();
+        targetAlpha = visisble ? 1 : 0;
+        targetLocalPosition = targetPos;
     }
 
     public void SetTowerPlacement(TowerPlacementSpot parentTowerPlacementSpot)
@@ -24,9 +30,14 @@ public class IndexSquare : MonoBehaviour
     {
         if(sr != null)
         {
+            transform.localPosition = Vector3.Lerp(transform.localPosition, targetLocalPosition, Time.deltaTime * 10);
+            Color c = sr.color;
+            c.a = Mathf.Lerp(c.a, targetAlpha, Time.deltaTime * 10);
+
             bool canPurchase = MasterController.Instance.CheckCurrency(index);
             //visual touches, if we can't purchase grey out with no response. If we can purchase, make it normally colored and scale as if its a button
-            sr.color = canPurchase ? Color.white : Color.grey;
+            c = canPurchase ? new(1, 1, 1, c.a) : new(0.5f, 0.5f, 0.5f, c.a);
+            sr.color = c;
             transform.localScale = canPurchase ? Vector3.Lerp(transform.localScale, Vector3.one * targetScale, Time.deltaTime * 6.5f) : Vector3.one;
         }
     }

--- a/TowerDefense/Assets/Scripts/TowerScripts/TowerPlacement.cs
+++ b/TowerDefense/Assets/Scripts/TowerScripts/TowerPlacement.cs
@@ -1,5 +1,7 @@
+using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
+using System.Collections;
 
 [RequireComponent(typeof(SpriteRenderer))]
 [RequireComponent(typeof(BoxCollider2D))]
@@ -11,13 +13,15 @@ public class TowerPlacementSpot : MonoBehaviour
     private GameObject menuObject;
     private GameObject placedTower;
 
+    private List<IndexSquare> menuObjects = new();
+
     public bool HasTower => hasTower;
     public Vector3 PlacementPosition => transform.position;
 
 
     private void OnMouseDown()
     {
-        if (hasTower) return;          // Already occupied — ignore clicks
+        if (hasTower || closing) return;          // Already occupied — ignore clicks
 
         if (menuOpen) CloseMenu();
         else OpenMenu();
@@ -34,6 +38,8 @@ public class TowerPlacementSpot : MonoBehaviour
 
         float radius = 1.5f;
 
+        menuObjects.Clear();
+
         for(int i = 0; i < MasterController.Instance.NumberOfAvailableTowers; i++)
         {
             float alpha = (float)i / Mathf.Max(MasterController.Instance.NumberOfAvailableTowers, 1);
@@ -44,23 +50,43 @@ public class TowerPlacementSpot : MonoBehaviour
             //Create the image with the tower to visually represent it
             GameObject towerButton = new GameObject($"{MasterController.Instance.GetTowerName(i)} button", typeof(SpriteRenderer), typeof(BoxCollider2D), typeof(IndexSquare));
             towerButton.transform.SetParent(menuObject.transform, false);
-            towerButton.transform.localPosition = new(x, y, 0);
+            towerButton.transform.localPosition = Vector3.zero;
             SpriteRenderer sr = towerButton.GetComponent<SpriteRenderer>();
             sr.sprite = MasterController.Instance.GetTowerSprite(i);
+            sr.color = Color.clear;
+            sr.sortingOrder = -2;
             towerButton.GetComponent<BoxCollider2D>().size = Vector2.one;
 
             //Setup click handler
             IndexSquare iSqr = towerButton.GetComponent<IndexSquare>();
-            iSqr.Setup(i);
+            iSqr.Setup(i, new(x, y, 0), true);
             iSqr.SetTowerPlacement(this);
+            menuObjects.Add(iSqr);
         }
-
     }
+    bool closing = false;
 
     public void CloseMenu()
     {
+        if(!closing)
+        {
+            StartCoroutine(CloseMenuAnim());
+        }
+    }
+
+
+    private IEnumerator CloseMenuAnim()
+    {
+        closing = true;
+        for(int i = 0; i < menuObjects.Count; i++)
+        {
+            menuObjects[i].Setup(i, Vector3.zero, false);
+        }
+        yield return new WaitForSeconds(.1f);
+
         menuOpen = false;
         if (menuObject != null) Destroy(menuObject);
+        closing = false;
     }
 
     public void MarkAsOccupied(GameObject tower = null)


### PR DESCRIPTION
Towers can now target more than 1 creep at a time if set up. Also: (even though not in the task directly)
- Tower data assets now have a little spot to put notes down for that tower
- Main Menu rebalanced so you can't lose on it
- Tower placement UI beautified even further for no reason other than why not
- Level 1 pathing setup fixed so it's not fucked. (You're supposed to list the spline indexes, not the fucking knot indexes. There is a wiki for a reason)
- Level 1 UI now uses the HUD prefab so its up to date