### PR TITLE
Level 1 Balance Changes

### DIFF
--- a/TowerDefense/Assets/DataAssets/Creeps/BasicCreep.asset
+++ b/TowerDefense/Assets/DataAssets/Creeps/BasicCreep.asset
@@ -13,7 +13,7 @@ MonoBehaviour:
   m_Name: BasicCreep
   m_EditorClassIdentifier: Assembly-CSharp::CreepData
   animationData: {fileID: 11400000, guid: 4131b7a111d37aa45a974a9c8965a110, type: 2}
-  maxHealth: 2
+  maxHealth: 1
   moveSpeed: 2
   currencyOnDeath: 1
   damageToBase: 1

--- a/TowerDefense/Assets/DataAssets/Towers/IV_Stingray.asset
+++ b/TowerDefense/Assets/DataAssets/Towers/IV_Stingray.asset
@@ -15,11 +15,11 @@ MonoBehaviour:
   projectileSprite: {fileID: 0}
   animationData: {fileID: 11400000, guid: 5b0213fd42729554ba5f8037a41af7cd, type: 2}
   targetRadius: 2
-  damagePerShot: 2
-  shotsPerSecond: 3
+  damagePerShot: 1
+  shotsPerSecond: 2
   projectileTargetTime: 0
   firingDelay: 0
   creepsToTarget: 1
-  slowable: 1
-  cost: 14
+  slowable: 0
+  cost: 45
   notes: Close Range Tower with high attack rate, immune to slowing effects

--- a/TowerDefense/Assets/DataAssets/Towers/Pill_Fish.asset
+++ b/TowerDefense/Assets/DataAssets/Towers/Pill_Fish.asset
@@ -21,5 +21,5 @@ MonoBehaviour:
   firingDelay: 0.4
   creepsToTarget: 1
   slowable: 1
-  cost: 10
+  cost: 30
   notes: Basic tower that does basic things - Change in future

--- a/TowerDefense/Assets/Scenes/Level1.unity
+++ b/TowerDefense/Assets/Scenes/Level1.unity
@@ -239,50 +239,43 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9efb4a3ee84c1bd4c85f31d758697dc9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::MasterController
-  startingCurrency: 10
+  startingCurrency: 30
   startingHealth: 5
   waves:
   - name: Wave 1
     creepSpawnOrder:
     - creepIndexToSpawn: 0
-      numberToSpawn: 30
+      numberToSpawn: 15
       pathIndex: 0
       deleyPerCreep: 2
     delayBeforeWave: 5
   - name: Wave 2
     creepSpawnOrder:
     - creepIndexToSpawn: 0
-      numberToSpawn: 60
+      numberToSpawn: 15
       pathIndex: 0
       deleyPerCreep: 1
     delayBeforeWave: 5
   - name: Wave 3
     creepSpawnOrder:
     - creepIndexToSpawn: 0
-      numberToSpawn: 90
+      numberToSpawn: 25
       pathIndex: 0
-      deleyPerCreep: 0.5
+      deleyPerCreep: 0.75
     delayBeforeWave: 5
   - name: Wave 4
     creepSpawnOrder:
     - creepIndexToSpawn: 0
-      numberToSpawn: 120
+      numberToSpawn: 35
       pathIndex: 0
-      deleyPerCreep: 0.5
+      deleyPerCreep: 0.33
     delayBeforeWave: 5
   - name: Wave 5
     creepSpawnOrder:
     - creepIndexToSpawn: 0
-      numberToSpawn: 150
+      numberToSpawn: 75
       pathIndex: 0
-      deleyPerCreep: 0.5
-    delayBeforeWave: 5
-  - name: Wave 6
-    creepSpawnOrder:
-    - creepIndexToSpawn: 0
-      numberToSpawn: 180
-      pathIndex: 0
-      deleyPerCreep: 0.5
+      deleyPerCreep: 0.29
     delayBeforeWave: 5
   paths:
   - 0
@@ -296,7 +289,6 @@ MonoBehaviour:
   towerParent: {fileID: 778779257}
   towerKeys:
   - Pill_Fish
-  - IV_Stingray
   creepKeys:
   - BasicCreep
   pauseSpawning: 0
@@ -2671,6 +2663,10 @@ PrefabInstance:
     - target: {fileID: 388735597552235667, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
       propertyPath: m_AnchoredPosition.y
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1148203398299138413, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
+      propertyPath: 'playRates.Array.data[2]'
+      value: 10
       objectReference: {fileID: 0}
     - target: {fileID: 1205211209080751598, guid: 17bf8386fd0dd1841946348467bf6aed, type: 3}
       propertyPath: m_Pivot.x

--- a/TowerDefense/Assets/Scenes/Prototype.unity
+++ b/TowerDefense/Assets/Scenes/Prototype.unity
@@ -149,18 +149,34 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 9efb4a3ee84c1bd4c85f31d758697dc9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::MasterController
-  startingCurrency: 99999999
+  startingCurrency: 50
   startingHealth: 5
   waves:
   - name: Wave 1
     creepSpawnOrder:
-    - creepIndexToSpawn: 2
+    - creepIndexToSpawn: 0
+      numberToSpawn: 5
+      pathIndex: 0
+      deleyPerCreep: 1
+    - creepIndexToSpawn: 0
+      numberToSpawn: 5
+      pathIndex: 0
+      deleyPerCreep: 1
+    - creepIndexToSpawn: 0
       numberToSpawn: 5
       pathIndex: 0
       deleyPerCreep: 1
     delayBeforeWave: 5
   - name: Wave 2
     creepSpawnOrder:
+    - creepIndexToSpawn: 0
+      numberToSpawn: 5
+      pathIndex: 0
+      deleyPerCreep: 0.75
+    - creepIndexToSpawn: 0
+      numberToSpawn: 5
+      pathIndex: 0
+      deleyPerCreep: 0.75
     - creepIndexToSpawn: 0
       numberToSpawn: 5
       pathIndex: 0
@@ -189,6 +205,12 @@ MonoBehaviour:
     delayBeforeWave: 5
   paths:
   - 0
+  maxButtonUses: 1
+  rewindTime: 5
+  rewindActionTime: 3
+  slowPercent: 0.75
+  slowTime: 5
+  damageDealt: 1
   creepParent: {fileID: 1313844446}
   towerParent: {fileID: 778779257}
   towerKeys:
@@ -199,6 +221,7 @@ MonoBehaviour:
   - BasicCreep
   - BossCreep
   - SlowCreep
+  pauseSpawning: 0
 --- !u!4 &37661630
 Transform:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Changed values on creeps (HP), towers (base cost) and balanced waves so that waves are challenging enough but can be completed within the scope of the level if played correctly.

Wave 1 is 15 creeps at a spawn delay of 2
Wave 2 is 15 creeps at a spawn delay of 1
Wave 3 is 25 creeps at a spawn delay of .75
Wave 4 is 35 creeps at a spawn delay of .33
Wave 5 is 75 creeps at a spawn delay of .29

In its current state, Wave 5 is 100% clearable with all three towers down, but is impossible without all 3, and the creeps get close to the end without actually leaking.

Prototype changes are there as I was initially messing with values on that level. They have no impact on anything outside of the prototype scene.